### PR TITLE
Update event.json for Auckland serverlessDays

### DIFF
--- a/src/events.json
+++ b/src/events.json
@@ -226,7 +226,7 @@
     "label": "Auckland",
     "loc": {"lat": -36.8485, "lng": 174.7633},
     "email": "auckland@serverlessdays.io",
-    "date": "20 April 2020",
+    "date": "Postponed until further notice",
     "website": "https://serverless.org.nz/",
     "image": "https://res.cloudinary.com/dtsyxzxfx/image/upload/f_auto,q_auto/v1578469767/2020/dan-freeman-hIKVSVKH7No-unsplash_mini.png"
 },{


### PR DESCRIPTION
Updating Auckland serverless days date with "Postponed until further notice" text.