### PR TITLE
Adding São Paulo to events.json

### DIFF
--- a/src/events.json
+++ b/src/events.json
@@ -149,6 +149,8 @@
   {
     "label": "São Paulo",
     "loc": { "lat": -23.5689, "lng": -46.6513 },
+    "date": "21 October 2021",
+    "website": "https://saopaulo.serverlessdays.io",
     "email": "saopaulo@serverlessdays.io"
   },
   {


### PR DESCRIPTION
I assume we will have a saopaulo.serverlessdays.io page!

To do (not related to this PR)
- [x] Date
- [ ] Landing page linking to our tickets page
- [ ] Image for São Paulo
